### PR TITLE
Fixed bug where Collection was passed a datetime

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/banyule_vic_gov_au.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/banyule_vic_gov_au.py
@@ -123,7 +123,7 @@ class Source:
             if waste_date_match is None:
                 continue
 
-            waste_date = datetime.strptime(waste_date_match[1], '%d/%m/%Y')
+            waste_date = datetime.strptime(waste_date_match[1], '%d/%m/%Y').date()
 
             # Base icon on type
             waste_icon = ICON_MAP.get(waste_type.lower(), 'mdi:trash-can')


### PR DESCRIPTION
The source I created accidentally passed datetime objects to the Collection constructor instead of Date objects. A quick fix for that.

While I wrote the source a while ago I didn't actually use it until recently. It "passed" ```test_sources.py``` since it quite happily dumps datetimes as strings 🙃 